### PR TITLE
Improve execution timing, separate solving + total duration

### DIFF
--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -73,7 +73,9 @@ class RunCommand extends Command
         $solution->setPuzzleInput($puzzleInput);
 
         // Run the actual solution
+        $solvingStart = now();
         $solution->solve();
+        $solvingDuration = now()->diff($solvingStart)->forHumans(['minimumUnit' => 'µs', 'short' => true, 'parts' => 2, 'join' => '']);
 
         // Print the answer from the solution
         $answerDescription = $solution->getPuzzleAnswerDescription();
@@ -111,8 +113,8 @@ class RunCommand extends Command
         }
 
         // Print the duration
-        $duration = now()->diff(Carbon::createFromTimestamp(LARAVEL_START))->forHumans(['minimumUnit' => 'ms', 'short' => true, 'parts' => 2]);
-        $this->comment("Duration: {$duration}");
+        $totalDuration = now()->diff(Carbon::createFromTimestamp(LARAVEL_START))->forHumans(['minimumUnit' => 'ms', 'short' => true, 'parts' => 2, 'join' => '']);
+        $this->comment("Duration: {$solvingDuration} solving, {$totalDuration} total");
 
         return self::SUCCESS;
     }


### PR DESCRIPTION
With recent additions, time spent on I/O for getting input and stored previous answers can be significant, especially with AocdWrapper.

This PR adds another timer in order to differentiate between time spent on actual puzzle solving logic and time spent in total. It also introduces microsecond timings which makes sense for very fast tasks. See example:

Before:
```Duration: 408 ms```

After:
```Duration: 51µs solving, 408ms total```