### PR TITLE
Add ability to read puzzle input from stdin

### DIFF
--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -6,12 +6,12 @@ namespace NorthernBytes\AocHelper\Commands;
 
 use Carbon\Carbon;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use NorthernBytes\AocHelper\Interfaces\PuzzleAnswerProviderInterface;
 use NorthernBytes\AocHelper\Interfaces\PuzzleInputProviderInterface;
 use NorthernBytes\AocHelper\Puzzle;
 use NorthernBytes\AocHelper\PuzzleInputFileReader;
+use NorthernBytes\AocHelper\StdinReader;
 use NorthernBytes\AocHelper\Support\AocdWrapper;
 
 use function Termwind\render;
@@ -49,13 +49,15 @@ class RunCommand extends Command
         // Print puzzle banner
         $this->announcePuzzle($year, $day, $part, $solution->getPuzzleName());
 
-        // Read puzzle input from file
+        // Read puzzle input
 
         /** @var PuzzleInputProviderInterface $inputProvider */
         $inputProvider = null;
 
         // TODO: This is a poc, should really happen somewhere else
-        if (config('aochelper.aocdwrapper.enable')) {
+        if (StdinReader::inputAvailable()) {
+            $inputProvider = new StdinReader;
+        } elseif (config('aochelper.aocdwrapper.enable')) {
             $inputProvider = new AocdWrapper;
         } else {
             $inputProvider = new PuzzleInputFileReader;

--- a/src/StdinReader.php
+++ b/src/StdinReader.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NorthernBytes\AocHelper;
+
+use NorthernBytes\AocHelper\Interfaces\PuzzleInputProviderInterface;
+
+class StdinReader implements PuzzleInputProviderInterface
+{
+    public static function inputAvailable(): bool
+    {
+        $read = [STDIN];
+        $write = [];
+        $except = [];
+
+        return (bool) stream_select($read, $write, $except, 0, 0);
+    }
+
+    public function getPuzzleInput(int $year, int $day): string
+    {
+        if (self::inputAvailable()) {
+            return stream_get_contents(STDIN);
+        }
+
+        return '';
+    }
+}


### PR DESCRIPTION
This PR adds the ability to read puzzle input from stdin. This allows ad-hoc piping of input data for quickly testing alternative inputs.

When available, input on stdin takes precedence over any other available input providers.

Examples:

```./aoc aoc:run --year 2015 1 1 < path/to/2015/input/d1.data```

```echo 'random-input-here' |./aoc aoc:run --year 2015 1 1```
